### PR TITLE
Remove bytebuddy dependency

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -38,7 +38,6 @@ dependencies {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
 	testImplementation "org.mockito:mockito-core:4.8.0"
-	testImplementation "net.bytebuddy:byte-buddy:1.12.18" //Used by Mockito, try removing in future
 
 	testImplementation 'com.openpojo:openpojo:0.9.1'
 


### PR DESCRIPTION
bytebuddy is a dependency for mokito and I had to update the version to pull in bug fixes ahead of mokito. No longer needed.