### PR TITLE
Bump node version for server to 18.12.1

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -51,7 +51,7 @@ test {
 
 frontend {
 	nodeDistributionProvided = false
-	nodeVersion = '14.16.1'
+	nodeVersion = '18.12.1'
 }
 
 sonarqube {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,6 +1,25 @@
 {
+	"name": "server",
+	"lockfileVersion": 2,
 	"requires": true,
-	"lockfileVersion": 1,
+	"packages": {
+		"": {
+			"dependencies": {
+				"jquery": "3.6.1",
+				"normalize.css": "8.0.1"
+			}
+		},
+		"node_modules/jquery": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
+			"integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw=="
+		},
+		"node_modules/normalize.css": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+			"integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
+		}
+	},
 	"dependencies": {
 		"jquery": {
 			"version": "3.6.1",


### PR DESCRIPTION
Bump version of node used by server build to 18.12.1, the latest LTS version. It is needed because it has an arm64 release, needed to build on M1 Macs.